### PR TITLE
fix: 修改react-native-drax因reanimated版本升级引起的打包问题

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -30,4 +30,10 @@ export const INITIAL_REANIMATED_POSITION = {
     addListener(): void {},
     removeListener(): void {},
     modify(): void {},
+    get(): { x: number; y: number } {
+        return this.value;
+    },
+    set(value: { x: number; y: number }): void {
+        this.value = value;
+    },
 };


### PR DESCRIPTION
# Summary

* 之前实现了[SharedValue<Position> react-native-reanimated v2.x 的接口，对于3.x接口不兼容 ，导致此问题  ，
添加react-native-reanimated v3.x 新增接口get set 即可
* https://github.com/react-native-oh-library/react-native-drax/issues/11   
<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

